### PR TITLE
Resolve a know vulnerability in debug package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "dependencies": {
-    "debug": "0.7.4"
+    "debug": "3.1.0"
   },
   "devDependencies": {
     "autod": "*",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "dependencies": {
-    "debug": "3.1.0"
+    "debug": "^3.1.0"
   },
   "devDependencies": {
     "autod": "*",


### PR DESCRIPTION
`debug` package in versions up to `2.6.9` and between `3.0.0` and `3.1.0` has been detected with Regular Expression Denial of Service vulnerability.
Since there have been no breaking changes, this update is safe and will eliminate the security issue.